### PR TITLE
feat(freejobalert): add ad removal and license bypass patches

### DIFF
--- a/patches/src/main/kotlin/app/freejobalert/patches/ad/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/freejobalert/patches/ad/Fingerprints.kt
@@ -1,0 +1,123 @@
+package app.freejobalert.patches.ad
+
+import app.morphe.patcher.Fingerprint
+
+// ── Flutter Google Mobile Ads plugin ──────────────────────────────────────────
+// All ad types are loaded via a load() method on each Flutter ad wrapper class.
+// These classes are NOT obfuscated (they come from the flutter plugin).
+
+/** Banner ad load — io.flutter.plugins.googlemobileads.FlutterBannerAd */
+object FlutterBannerAdLoadFingerprint : Fingerprint(
+    definingClass = "Lio/flutter/plugins/googlemobileads/FlutterBannerAd;",
+    name = "load",
+    returnType = "V",
+    parameters = listOf()
+)
+
+/** Interstitial ad load — io.flutter.plugins.googlemobileads.FlutterInterstitialAd */
+object FlutterInterstitialAdLoadFingerprint : Fingerprint(
+    definingClass = "Lio/flutter/plugins/googlemobileads/FlutterInterstitialAd;",
+    name = "load",
+    returnType = "V",
+    parameters = listOf()
+)
+
+/** Rewarded ad load — io.flutter.plugins.googlemobileads.FlutterRewardedAd */
+object FlutterRewardedAdLoadFingerprint : Fingerprint(
+    definingClass = "Lio/flutter/plugins/googlemobileads/FlutterRewardedAd;",
+    name = "load",
+    returnType = "V",
+    parameters = listOf()
+)
+
+/** Rewarded interstitial ad load */
+object FlutterRewardedInterstitialAdLoadFingerprint : Fingerprint(
+    definingClass = "Lio/flutter/plugins/googlemobileads/FlutterRewardedInterstitialAd;",
+    name = "load",
+    returnType = "V",
+    parameters = listOf()
+)
+
+/** App Open ad load */
+object FlutterAppOpenAdLoadFingerprint : Fingerprint(
+    definingClass = "Lio/flutter/plugins/googlemobileads/FlutterAppOpenAd;",
+    name = "load",
+    returnType = "V",
+    parameters = listOf()
+)
+
+/** Native ad load */
+object FlutterNativeAdLoadFingerprint : Fingerprint(
+    definingClass = "Lio/flutter/plugins/googlemobileads/FlutterNativeAd;",
+    name = "load",
+    returnType = "V",
+    parameters = listOf()
+)
+
+/** Ad Manager banner ad load */
+object FlutterAdManagerBannerAdLoadFingerprint : Fingerprint(
+    definingClass = "Lio/flutter/plugins/googlemobileads/FlutterAdManagerBannerAd;",
+    name = "load",
+    returnType = "V",
+    parameters = listOf()
+)
+
+/** Ad Manager interstitial ad load */
+object FlutterAdManagerInterstitialAdLoadFingerprint : Fingerprint(
+    definingClass = "Lio/flutter/plugins/googlemobileads/FlutterAdManagerInterstitialAd;",
+    name = "load",
+    returnType = "V",
+    parameters = listOf()
+)
+
+// ── Pairip license check ──────────────────────────────────────────────────────
+
+/**
+ * Local installer check — returns true if installed from Play Store.
+ * We return false to skip it (false = bypass, the check is then ignored upstream).
+ */
+object PairiplocalInstallerCheckFingerprint : Fingerprint(
+    definingClass = "Lcom/pairip/licensecheck/LicenseClient;",
+    name = "performLocalInstallerCheck",
+    returnType = "Z",
+    parameters = listOf()
+)
+
+/**
+ * processResponse — called with the server license response code.
+ * responseCode 0 = LICENSED. We force p1=0 so it always takes the success path.
+ */
+object PairipProcessResponseFingerprint : Fingerprint(
+    definingClass = "Lcom/pairip/licensecheck/LicenseClient;",
+    name = "processResponse",
+    returnType = "V",
+    parameters = listOf("I", "Landroid/os/Bundle;")
+)
+
+/**
+ * initializeLicenseCheck — public entry point called by the app.
+ * Return-void to skip the entire check pipeline.
+ */
+object PairipInitializeLicenseCheckFingerprint : Fingerprint(
+    definingClass = "Lcom/pairip/licensecheck/LicenseClient;",
+    name = "initializeLicenseCheck",
+    returnType = "V",
+    parameters = listOf()
+)
+object AbstractAdViewAdapterRequestBannerFingerprint : Fingerprint(
+    definingClass = "Lcom/google/ads/mediation/AbstractAdViewAdapter;",
+    name = "requestBannerAd",
+    returnType = "V"
+)
+
+object AbstractAdViewAdapterRequestInterstitialFingerprint : Fingerprint(
+    definingClass = "Lcom/google/ads/mediation/AbstractAdViewAdapter;",
+    name = "requestInterstitialAd",
+    returnType = "V"
+)
+
+object AbstractAdViewAdapterShowInterstitialFingerprint : Fingerprint(
+    definingClass = "Lcom/google/ads/mediation/AbstractAdViewAdapter;",
+    name = "showInterstitial",
+    returnType = "V"
+)

--- a/patches/src/main/kotlin/app/freejobalert/patches/ad/FreeJobAlertAdRemovalPatch.kt
+++ b/patches/src/main/kotlin/app/freejobalert/patches/ad/FreeJobAlertAdRemovalPatch.kt
@@ -1,0 +1,40 @@
+package app.freejobalert.patches.ad
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import app.freejobalert.patches.shared.Constants.COMPATIBILITY_FREEJOBALERT
+
+@Suppress("unused")
+val freeJobAlertAdRemovalPatch = bytecodePatch(
+    name = "FreeJobAlert Ad Removal",
+    description = "Removes all Google AdMob ads (banner, interstitial, rewarded, app open, native).",
+    default = true
+) {
+    compatibleWith(COMPATIBILITY_FREEJOBALERT)
+
+    execute {
+        // Smali snippet to return-void immediately — prevents any ad from loading
+        val returnVoid = "return-void"
+
+        // ── Flutter Google Mobile Ads — all ad formats ────────────────────────
+        // Each load() call is intercepted and returned immediately so no ad
+        // request is ever made to Google's servers.
+
+        FlutterBannerAdLoadFingerprint.method.addInstructions(0, returnVoid)
+        FlutterInterstitialAdLoadFingerprint.method.addInstructions(0, returnVoid)
+        FlutterRewardedAdLoadFingerprint.method.addInstructions(0, returnVoid)
+        FlutterRewardedInterstitialAdLoadFingerprint.method.addInstructions(0, returnVoid)
+        FlutterAppOpenAdLoadFingerprint.method.addInstructions(0, returnVoid)
+        FlutterNativeAdLoadFingerprint.method.addInstructions(0, returnVoid)
+        FlutterAdManagerBannerAdLoadFingerprint.method.addInstructions(0, returnVoid)
+        FlutterAdManagerInterstitialAdLoadFingerprint.method.addInstructions(0, returnVoid)
+
+        // ── Legacy AdMob mediation adapter ────────────────────────────────────
+        AbstractAdViewAdapterRequestBannerFingerprint.methodOrNull
+            ?.addInstructions(0, returnVoid)
+        AbstractAdViewAdapterRequestInterstitialFingerprint.methodOrNull
+            ?.addInstructions(0, returnVoid)
+        AbstractAdViewAdapterShowInterstitialFingerprint.methodOrNull
+            ?.addInstructions(0, returnVoid)
+    }
+}

--- a/patches/src/main/kotlin/app/freejobalert/patches/misc/FreeJobAlertLicenseBypassPatch.kt
+++ b/patches/src/main/kotlin/app/freejobalert/patches/misc/FreeJobAlertLicenseBypassPatch.kt
@@ -1,0 +1,37 @@
+package app.freejobalert.patches.misc
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import app.freejobalert.patches.ad.PairipInitializeLicenseCheckFingerprint
+import app.freejobalert.patches.ad.PairipProcessResponseFingerprint
+import app.freejobalert.patches.ad.PairiplocalInstallerCheckFingerprint
+import app.freejobalert.patches.shared.Constants.COMPATIBILITY_FREEJOBALERT
+
+@Suppress("unused")
+val freeJobAlertLicenseBypassPatch = bytecodePatch(
+    name = "FreeJobAlert License Bypass",
+    description = "Bypasses the Pairip Play Store installation check so the app launches normally.",
+    default = true
+) {
+    compatibleWith(COMPATIBILITY_FREEJOBALERT)
+
+    execute {
+        // 1. Skip the entire license check pipeline at the entry point.
+        //    initializeLicenseCheck() is the public method the app calls on startup.
+        PairipInitializeLicenseCheckFingerprint.method
+            .addInstructions(0, "return-void")
+
+        // 2. Make performLocalInstallerCheck() always return false (= not from Play Store,
+        //    but this return value is only used to decide whether to skip the remote check —
+        //    since we already killed initializeLicenseCheck above, this is defense-in-depth).
+        PairiplocalInstallerCheckFingerprint.method.addInstructions(0, """
+            const/4 v0, 0x0
+            return v0
+        """.trimIndent())
+
+        // 3. Force processResponse() to treat every server reply as responseCode=0 (LICENSED).
+        //    p1 is the responseCode parameter; setting it to 0 routes into the success branch.
+        PairipProcessResponseFingerprint.method
+            .addInstructions(0, "const/4 p1, 0x0")
+    }
+}

--- a/patches/src/main/kotlin/app/freejobalert/patches/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/freejobalert/patches/shared/Constants.kt
@@ -1,0 +1,17 @@
+package app.freejobalert.patches.shared
+
+import app.morphe.patcher.patch.ApkFileType
+import app.morphe.patcher.patch.AppTarget
+import app.morphe.patcher.patch.Compatibility
+
+object Constants {
+    val COMPATIBILITY_FREEJOBALERT = Compatibility(
+        name = "FreeJobAlert",
+        packageName = "com.freejobalert",
+        apkFileType = ApkFileType.XAPK,
+        appIconColor = 0x1565C0,
+        targets = listOf(
+            AppTarget(version = "1.0.0")
+        )
+    )
+}

--- a/patches/src/main/kotlin/app/truecloud/patches/ad/TrueCloudAdRemovalPatch.kt
+++ b/patches/src/main/kotlin/app/truecloud/patches/ad/TrueCloudAdRemovalPatch.kt
@@ -1,4 +1,4 @@
-package app.truecloud.patches
+package app.truecloud.patches.ad
 
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions


### PR DESCRIPTION
Introduce patches to remove Google Mobile Ads and bypass the Pairip license check for the FreeJobAlert application.

Includes new fingerprints and compatibility constants. Also renames TrueCloud ad removal patch for better organization.