### PR TITLE
feat(smashit-premium): add premium unlock patch

### DIFF
--- a/patches/src/main/kotlin/app/smashit/patches/premium/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/smashit/patches/premium/Fingerprints.kt
@@ -1,0 +1,58 @@
+package app.smashit.patches.premium
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.methodCall
+import com.android.tools.smali.dexlib2.AccessFlags
+
+/**
+ * AndroidStore.ownsPremiumProduct() — top-level Java-side premium check.
+ * Confirmed smali: public ownsPremiumProduct()Z
+ */
+object OwnsPremiumProductFingerprint : Fingerprint(
+    definingClass = "Lcom/mediocre/smashhit/AndroidStore;",
+    name = "ownsPremiumProduct",
+    returnType = "Z",
+    parameters = listOf(),
+    accessFlags = listOf(AccessFlags.PUBLIC)
+)
+
+/**
+ * CommandThreadsafeModel.isProductOwned(String) — per-product check.
+ * Called by the "isproductowned" JNI command handler.
+ * Confirmed smali: public declared-synchronized isProductOwned(String)Z
+ */
+object IsProductOwnedFingerprint : Fingerprint(
+    definingClass = "Lcom/mediocre/smashhit/CommandThreadsafeModel;",
+    name = "isProductOwned",
+    returnType = "Z",
+    parameters = listOf("Ljava/lang/String;"),
+    filters = listOf(
+        methodCall(
+            definingClass = "Ljava/util/HashSet;",
+            name = "contains"
+        )
+    )
+)
+
+/**
+ * "hasrefreshedownedproducts" command handler lambda in CommandHandler.
+ * The C++ engine polls this BEFORE it ever calls "isproductowned".
+ * Must return "true" string for the engine to proceed to the product check.
+ * Confirmed smali: synthetic lambda$setupCommands$1$...(String[])String
+ */
+object HasRefreshedOwnedProductsFingerprint : Fingerprint(
+    definingClass = "Lcom/mediocre/smashhit/CommandHandler;",
+    returnType = "Ljava/lang/String;",
+    accessFlags = listOf(AccessFlags.SYNTHETIC),
+    parameters = listOf("[Ljava/lang/String;"),
+    filters = listOf(
+        methodCall(
+            definingClass = "Ljava/util/concurrent/atomic/AtomicBoolean;",
+            name = "get"
+        ),
+        methodCall(
+            definingClass = "Lcom/mediocre/smashhit/CommandHandler;",
+            name = "boolToString"
+        )
+    )
+)

--- a/patches/src/main/kotlin/app/smashit/patches/premium/SmashItPremiumPatch.kt
+++ b/patches/src/main/kotlin/app/smashit/patches/premium/SmashItPremiumPatch.kt
@@ -1,0 +1,43 @@
+package app.smashit.patches.premium
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import app.smashit.patches.shared.Constants.COMPATIBILITY_SMASHIT
+
+@Suppress("unused")
+val smashItPremiumPatch = bytecodePatch(
+    name = "Smash Hit Premium Unlock",
+    description = "Unlocks premium and all game modes without purchase.",
+    default = true
+) {
+    compatibleWith(COMPATIBILITY_SMASHIT)
+
+    execute {
+        // 1. AndroidStore.ownsPremiumProduct() → always return true.
+        //    Top-level Java-side premium check.
+        OwnsPremiumProductFingerprint.method.addInstructions(0, """
+            const/4 v0, 0x1
+            return v0
+        """.trimIndent())
+
+        // 2. CommandThreadsafeModel.isProductOwned(String) → always return true.
+        //    Called by the "isproductowned" command handler when C++ engine queries
+        //    whether a product ID is in the owned set.
+        //    Declared-synchronized: inject at index 1 (after monitor-enter)
+        //    and properly exit the monitor before returning.
+        IsProductOwnedFingerprint.method.addInstructions(1, """
+            const/4 p1, 0x1
+            monitor-exit p0
+            return p1
+        """.trimIndent())
+
+        // 3. "hasrefreshedownedproducts" handler → always return "true".
+        //    The C++ engine polls this flag before it will ever call "isproductowned".
+        //    Without this, the engine waits indefinitely for a purchase sync that
+        //    never completes on a patched app, so isProductOwned is never reached.
+        HasRefreshedOwnedProductsFingerprint.method.addInstructions(0, """
+            const-string p1, "true"
+            return-object p1
+        """.trimIndent())
+    }
+}

--- a/patches/src/main/kotlin/app/smashit/patches/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/smashit/patches/shared/Constants.kt
@@ -1,0 +1,17 @@
+package app.smashit.patches.shared
+
+import app.morphe.patcher.patch.ApkFileType
+import app.morphe.patcher.patch.AppTarget
+import app.morphe.patcher.patch.Compatibility
+
+object Constants {
+    val COMPATIBILITY_SMASHIT = Compatibility(
+        name = "Smash Hit",
+        packageName = "com.mediocre.smashhit",
+        apkFileType = ApkFileType.APK,
+        appIconColor = 0x1E88E5,
+        targets = listOf(
+            AppTarget(version = "1.5.14")
+        )
+    )
+}


### PR DESCRIPTION
Introduces a new patch to unlock premium features in Smash Hit. Modifies key methods to bypass premium checks for product ownership and purchase sync status.