### PR TITLE
feat!: Adding Jetpackjoyride 

### DIFF
--- a/patches/src/main/kotlin/app/jetpackjoyride/patches/billing/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/jetpackjoyride/patches/billing/Fingerprints.kt
@@ -1,0 +1,26 @@
+package app.jetpackjoyride.patches.billing
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.methodCall
+import app.morphe.patcher.string
+import com.android.tools.smali.dexlib2.AccessFlags
+
+/**
+ * GooglePlayPurchaseV2Service.RequestPurchaseInternal(String) — called on the UI thread
+ * when the player taps a purchase button. Normally launches the Play billing flow.
+ * We return-void immediately after calling SynchronizedOnPurchaseResult with a fake success,
+ * so the C++ engine is told the purchase succeeded without ever opening Google Play.
+ *
+ * Confirmed smali: private static RequestPurchaseInternal(String)V in classes6.dex
+ * Stable filter: logs "Attempting to request purchase for" — won't change across app updates.
+ */
+object RequestPurchaseInternalFingerprint : Fingerprint(
+    definingClass = "Lcom/halfbrick/mortar/GooglePlayPurchaseV2Service;",
+    name = "RequestPurchaseInternal",
+    returnType = "V",
+    parameters = listOf("Ljava/lang/String;"),
+    accessFlags = listOf(AccessFlags.PRIVATE, AccessFlags.STATIC),
+    filters = listOf(
+        string("Attempting to request purchase for ")
+    )
+)

--- a/patches/src/main/kotlin/app/jetpackjoyride/patches/billing/JetpackJoyrideBillingPatch.kt
+++ b/patches/src/main/kotlin/app/jetpackjoyride/patches/billing/JetpackJoyrideBillingPatch.kt
@@ -1,0 +1,33 @@
+package app.jetpackjoyride.patches.billing
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import app.jetpackjoyride.patches.shared.Constants.COMPATIBILITY_JETPACKJOYRIDE
+
+@Suppress("unused")
+val jetpackJoyrideBillingPatch = bytecodePatch(
+    name = "Jetpack Joyride Billing Bypass",
+    description = "Intercepts all in-app purchases and reports instant success to the game engine.",
+    default = true
+) {
+    compatibleWith(COMPATIBILITY_JETPACKJOYRIDE)
+
+    execute {
+        // RequestPurchaseInternal(String productId) is called on the UI thread whenever
+        // the player initiates a purchase. We skip the billing flow entirely and call
+        // SynchronizedOnPurchaseResult(productId, null, false, false, null) directly.
+        //
+        // SynchronizedOnPurchaseResult signature:
+        //   (String productId, String token, boolean cancelled, boolean pending, String error)
+        //
+        // Passing: cancelled=false, pending=false, error=null → tells C++ engine "purchase OK".
+        //
+        // The method has .registers 3 (p0=productId, v0, v1) — we only use p0, v0, v1.
+        RequestPurchaseInternalFingerprint.method.addInstructions(0, """
+            const/4 v0, 0x0
+            const/4 v1, 0x0
+            invoke-static {p0, v0, v0, v1, v0}, Lcom/halfbrick/mortar/GooglePlayPurchaseV2Service;->SynchronizedOnPurchaseResult(Ljava/lang/String;Ljava/lang/String;ZZLjava/lang/String;)V
+            return-void
+        """.trimIndent())
+    }
+}

--- a/patches/src/main/kotlin/app/jetpackjoyride/patches/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/jetpackjoyride/patches/shared/Constants.kt
@@ -1,0 +1,17 @@
+package app.jetpackjoyride.patches.shared
+
+import app.morphe.patcher.patch.ApkFileType
+import app.morphe.patcher.patch.AppTarget
+import app.morphe.patcher.patch.Compatibility
+
+object Constants {
+    val COMPATIBILITY_JETPACKJOYRIDE = Compatibility(
+        name = "Jetpack Joyride",
+        packageName = "com.halfbrick.jetpackjoyride",
+        apkFileType = ApkFileType.XAPK,
+        appIconColor = 0xF57F17,
+        targets = listOf(
+            AppTarget(version = "1.104.1")
+        )
+    )
+}


### PR DESCRIPTION
Intercepts RequestPurchaseInternal to report successful purchases to the game engine without launching the Google Play billing flow.