### PR TITLE
feat: add Doodle Jump billing bypass patch

### DIFF
--- a/patches/src/main/kotlin/app/doodlejump/patches/premium/DoodleJumpBillingPatch.kt
+++ b/patches/src/main/kotlin/app/doodlejump/patches/premium/DoodleJumpBillingPatch.kt
@@ -1,0 +1,76 @@
+package app.doodlejump.patches.premium
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
+import app.morphe.patcher.patch.bytecodePatch
+import app.doodlejump.patches.shared.Constants.COMPATIBILITY_DOODLEJUMP
+
+// Smali class descriptors
+private const val NOTIFICATION_CENTER = "Lcom/limasky/doodlejumpandroid/NotificationCenter;"
+private const val MSG_IAP_DATA = "Lcom/limasky/doodlejumpandroid/Messages\$MsgIAPTransactionData;"
+private const val MSG_IAP_PURCHASE_DATA = "Lcom/limasky/doodlejumpandroid/Messages\$MsgIAPPurchaseItemData;"
+private const val SKU = "unlock_full_game"
+
+/**
+ * Smali that creates a MsgIAPTransactionData with status=0 (Success) for
+ * "unlock_full_game" and sends it via NotificationCenter.sendMessageThreadSafe.
+ *
+ * Uses v0..v2. Safe at index 0 (onRestoreInventoryFinished has 7 registers,
+ * and handleMessage injection uses a label jump so registers are isolated).
+ *
+ * 0x29 = Msg_IAP_Transaction (confirmed in Messages.smali)
+ * 0x0  = IAPStatus.Success    (confirmed in IAPStatus.smali)
+ */
+private fun fakePurchaseSmali(skuRegister: String = "v1") = """
+    new-instance v0, $MSG_IAP_DATA
+    invoke-direct {v0}, $MSG_IAP_DATA-><init>()V
+    const-string $skuRegister, "$SKU"
+    iput-object $skuRegister, v0, $MSG_IAP_DATA->sku:Ljava/lang/String;
+    const/4 v2, 0x0
+    iput v2, v0, $MSG_IAP_DATA->status:I
+    const/16 $skuRegister, 0x29
+    invoke-static {$skuRegister, v0, v2, v2}, $NOTIFICATION_CENTER->sendMessageThreadSafe(ILjava/lang/Object;II)I
+""".trimIndent()
+
+@Suppress("unused")
+val doodleJumpBillingPatch = bytecodePatch(
+    name = "Doodle Jump Billing Bypass",
+    description = "Unlocks the full game by bypassing Google Play billing.",
+    default = true
+) {
+    compatibleWith(COMPATIBILITY_DOODLEJUMP)
+
+    execute {
+        // --- Patch 1: handleMessage intercept ---
+        // When C++ sends Msg_IAP_PurchaseItem (0x28), we intercept it and
+        // immediately return a fake success transaction instead of opening
+        // the Google Play billing tab.
+        //
+        // Strategy: at index 0 check if p1 == 0x28, if so fire fake success and return.
+        // handleMessage has .registers 8, so v0..v4 are safe locals.
+        HandleMessageFingerprint.method.addInstructionsWithLabels(0, """
+            const/16 v0, 0x28
+            if-ne p1, v0, :skip_purchase_intercept
+            if-eqz p2, :skip_purchase_intercept
+            check-cast p2, $MSG_IAP_PURCHASE_DATA
+            iget-object v1, p2, $MSG_IAP_PURCHASE_DATA->sku:Ljava/lang/String;
+            new-instance v0, $MSG_IAP_DATA
+            invoke-direct {v0}, $MSG_IAP_DATA-><init>()V
+            iput-object v1, v0, $MSG_IAP_DATA->sku:Ljava/lang/String;
+            const/4 v2, 0x0
+            iput v2, v0, $MSG_IAP_DATA->status:I
+            const/16 v1, 0x29
+            invoke-static {v1, v0, v2, v2}, $NOTIFICATION_CENTER->sendMessageThreadSafe(ILjava/lang/Object;II)I
+            const/4 v0, 0x0
+            return v0
+            :skip_purchase_intercept
+            nop
+        """)
+
+        // --- Patch 2: onRestoreInventoryFinished startup unlock ---
+        // On every app start, billing restores purchases. We inject a fake
+        // success here so the C++ engine receives the unlock even if the
+        // purchase was never made. Uses v0..v2 (method has .registers 7).
+        OnRestoreInventoryFinishedFingerprint.method.addInstructions(0, fakePurchaseSmali())
+    }
+}

--- a/patches/src/main/kotlin/app/doodlejump/patches/premium/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/doodlejump/patches/premium/Fingerprints.kt
@@ -1,0 +1,61 @@
+package app.doodlejump.patches.premium
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.methodCall
+import app.morphe.patcher.literal
+import com.android.tools.smali.dexlib2.AccessFlags
+
+/**
+ * GooglePlayBillingManager.handleMessage(int, Object, int)
+ *
+ * This is the Java-side dispatcher that receives messages from the C++ engine.
+ * When msg ID 0x28 (Msg_IAP_PurchaseItem) arrives, it queues a real billing
+ * flow which opens the Google Play purchase tab.
+ *
+ * We intercept here to detect msg 0x28 and immediately fire back a fake
+ * success MsgIAPTransactionData instead of launching the billing UI.
+ *
+ * Confirmed smali (classes/com/limasky/doodlejumpandroid/GooglePlayBillingManager.smali):
+ *   .method public handleMessage(ILjava/lang/Object;I)I
+ *   Contains: const/16 p3, 0x28  (line checking for PurchaseItem msg)
+ *   Then: iget-boolean ... isPurchaseOptionEnabled
+ */
+object HandleMessageFingerprint : Fingerprint(
+    definingClass = "Lcom/limasky/doodlejumpandroid/GooglePlayBillingManager;",
+    name = "handleMessage",
+    returnType = "I",
+    accessFlags = listOf(AccessFlags.PUBLIC),
+    parameters = listOf("I", "Ljava/lang/Object;", "I"),
+    filters = listOf(
+        literal(0x28),    // const/16 for Msg_IAP_PurchaseItem
+        methodCall(
+            definingClass = "Ljava/util/LinkedList;",
+            name = "addLast"
+        )
+    )
+)
+
+/**
+ * GooglePlayBillingManager.onRestoreInventoryFinished()
+ *
+ * Called on every startup when billing restores existing purchases.
+ * We inject a fake unlock here so the engine is notified on launch
+ * even when there is no pending purchase request.
+ */
+object OnRestoreInventoryFinishedFingerprint : Fingerprint(
+    definingClass = "Lcom/limasky/doodlejumpandroid/GooglePlayBillingManager;",
+    name = "onRestoreInventoryFinished",
+    returnType = "V",
+    accessFlags = listOf(AccessFlags.PUBLIC),
+    parameters = listOf(
+        "Lcom/android/billingclient/api/BillingResult;",
+        "Ljava/util/List;",
+        "Lcom/limasky/doodlejumpandroid/GooglePlayBillingManager\$JobRequest;"
+    ),
+    filters = listOf(
+        methodCall(
+            definingClass = "Lcom/android/billingclient/api/BillingResult;",
+            name = "getResponseCode"
+        )
+    )
+)

--- a/patches/src/main/kotlin/app/doodlejump/patches/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/doodlejump/patches/shared/Constants.kt
@@ -1,0 +1,17 @@
+package app.doodlejump.patches.shared
+
+import app.morphe.patcher.patch.ApkFileType
+import app.morphe.patcher.patch.AppTarget
+import app.morphe.patcher.patch.Compatibility
+
+object Constants {
+    val COMPATIBILITY_DOODLEJUMP = Compatibility(
+        name = "Doodle Jump",
+        packageName = "com.lima.doodlejump",
+        apkFileType = ApkFileType.APK,
+        appIconColor = 0x66BB6A,
+        targets = listOf(
+            AppTarget(version = "3.11.38")
+        )
+    )
+}


### PR DESCRIPTION
- Intercepts GooglePlayBillingManager.handleMessage() for Msg_IAP_PurchaseItem (0x28) to fire a fake MsgIAPTransactionData success instead of launching billing UI
- Injects startup unlock in onRestoreInventoryFinished() so C++ engine receives unlock_full_game signal before any purchase request arrives
- Targets com.lima.doodlejump v3.11.38