### PR TITLE
Fix "Is your Internet connection enabled?" message when using an ad blocker

### DIFF
--- a/patches/src/main/kotlin/app/hillclimb/patches/ad/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/hillclimb/patches/ad/Fingerprints.kt
@@ -31,3 +31,11 @@ object PlayRewardedVideoAdFingerprint : Fingerprint(
         methodCall(definingClass = "Lcom/fingersoft/game/firebase/CFirebaseAds;", name = "showVideoAd")
     )
 )
+
+object HasVideoCampaignsFingerprint : Fingerprint(
+    definingClass = "Lcom/fingersoft/game/MainActivity;",
+    name = "hasVideoCampaigns",
+    returnType = "I",
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
+    parameters = listOf("I"),
+)

--- a/patches/src/main/kotlin/app/hillclimb/patches/ad/HillClimbRewardedVideoPatch.kt
+++ b/patches/src/main/kotlin/app/hillclimb/patches/ad/HillClimbRewardedVideoPatch.kt
@@ -63,5 +63,7 @@ val hillClimbRewardedVideoPatch = bytecodePatch(
             invoke-static {}, $MAIN_ACTIVITY->onVideoCompletedSuccess()V
             return-void
         """.trimIndent())
+
+        HasVideoCampaignsFingerprint.method.returnEarly(1)
     }
 }


### PR DESCRIPTION
When using AdGuard or Pihole ads are not loaded which stops video rewards. This patch lies and says the ad campaigns are loaded.